### PR TITLE
Tail recursion optimization

### DIFF
--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/ast/Expressions.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/ast/Expressions.scala
@@ -67,7 +67,7 @@ case class LocalExpression(declarations: Seq[Variable],
  *  end
  *  }}}
  */
-case class ProcExpression(name: String, args: Seq[VariableOrRaw],
+case class ProcExpression(name: Option[VariableOrRaw], args: Seq[VariableOrRaw],
     body: Statement, flags: Seq[String]) extends Expression
     with ProcFunExpression {
   protected val keyword = "proc"
@@ -81,7 +81,7 @@ case class ProcExpression(name: String, args: Seq[VariableOrRaw],
  *  end
  *  }}}
  */
-case class FunExpression(name: String, args: Seq[VariableOrRaw],
+case class FunExpression(name: Option[VariableOrRaw], args: Seq[VariableOrRaw],
     body: Expression, flags: Seq[String]) extends Expression
     with ProcFunExpression {
   protected val keyword = "fun"

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/ast/Phrases.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/ast/Phrases.scala
@@ -19,9 +19,9 @@ case class RawLocalPhrase(declarations: Phrase, body: Phrase) extends PhraseNode
   posFrom(declarations, body)
 }
 
-case class ProcPhrase(name: String, args: Seq[VariableOrRaw], body: Phrase, flags: Seq[String]) extends PhraseNode
+case class ProcPhrase(name: Option[VariableOrRaw], args: Seq[VariableOrRaw], body: Phrase, flags: Seq[String]) extends PhraseNode
 
-case class FunPhrase(name: String, args: Seq[VariableOrRaw], body: Phrase, flags: Seq[String]) extends PhraseNode
+case class FunPhrase(name: Option[VariableOrRaw], args: Seq[VariableOrRaw], body: Phrase, flags: Seq[String]) extends PhraseNode
 
 case class CallPhrase(callable: Phrase, args: Seq[Phrase]) extends PhraseNode
 

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/ast/Statements.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/ast/Statements.scala
@@ -56,6 +56,10 @@ case class LocalStatement(declarations: Seq[Variable],
  */
 case class CallStatement(callable: Expression,
     args: Seq[Expression]) extends Statement with CallCommon
+    
+case class TailMarkerStatement(call: CallStatement) extends Statement {
+  override def syntax(indent: String) = call.syntax(indent)
+}
 
 /** If statement
  *

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/ast/TreeDSL.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/ast/TreeDSL.scala
@@ -124,7 +124,7 @@ trait TreeDSL {
    *  }
    *  }}}
    */
-  def PROC(name: String, args: Seq[VariableOrRaw],
+  def PROC(name: Option[VariableOrRaw], args: Seq[VariableOrRaw],
       flags: Seq[String] = Nil)(body: Statement) = {
     treeCopy.ProcExpression(body, name, args, body, flags)
   }
@@ -138,7 +138,7 @@ trait TreeDSL {
    *  }
    *  }}}
    */
-  def FUN(name: String, args: Seq[VariableOrRaw],
+  def FUN(name: Option[VariableOrRaw], args: Seq[VariableOrRaw],
       flags: Seq[String] = Nil)(body: Expression) = {
     treeCopy.FunExpression(body, name, args, body, flags)
   }

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/Desugar.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/Desugar.scala
@@ -22,7 +22,7 @@ object Desugar extends Transformer with TreeDSL {
 
     case thread @ ThreadStatement(body) =>
       atPos(thread) {
-        val proc = PROC("", Nil) {
+        val proc = PROC(None, Nil) {
           transformStat(body)
         }
 
@@ -31,7 +31,7 @@ object Desugar extends Transformer with TreeDSL {
 
     case lockStat @ LockStatement(lock, body) =>
       atPos(lockStat) {
-        val proc = PROC("", Nil) {
+        val proc = PROC(None, Nil) {
           transformStat(body)
         }
 

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/DesugarClass.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/DesugarClass.scala
@@ -299,7 +299,7 @@ object DesugarClass extends Transformer with TreeDSL {
     }
 
     atPos(method) {
-      PROC (name, Seq(selfParam, msgParam)) {
+      PROC (None, Seq(selfParam, msgParam)) {
         LOCAL (paramVars:_*) IN {
           withSelf(selfParam) {
             transformStat {

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/DesugarFunctor.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/DesugarFunctor.scala
@@ -121,7 +121,7 @@ object DesugarFunctor extends Transformer with TreeDSL {
 
     val allDecls = importedDecls ++ definedDecls ++ utilsDecls
 
-    FUN("<Apply>", Seq(importsParam)) {
+    FUN(None, Seq(importsParam)) {
       LOCAL (allDecls:_*) IN {
         val statements = new ListBuffer[Statement]
         def exec(statement: Statement) = statements += statement

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/Namer.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/Namer.scala
@@ -223,7 +223,7 @@ object Namer extends Transformer with TransformUtils with TreeDSL {
 
       withEnvironmentFromDecls(namedFormals) {
         treeCopy.ProcExpression(proc,
-            name,
+            resolveVariable(name),
             namedFormals,
             transformStat(body),
             flags)
@@ -241,7 +241,7 @@ object Namer extends Transformer with TransformUtils with TreeDSL {
 
       withEnvironmentFromDecls(namedFormals) {
         treeCopy.FunExpression(fun,
-            name,
+            resolveVariable(name),
             namedFormals,
             transformExpr(body),
             flags)
@@ -601,6 +601,15 @@ object Namer extends Transformer with TransformUtils with TreeDSL {
       case _ =>
         pattern
     }
+  }
+
+  /** Resolves an optional raw variable into an optional variable */
+  def resolveVariable(rawVar: Option[VariableOrRaw]): Option[VariableOrRaw] = {
+    rawVar.flatMap(_ match {
+      case RawVariable(name) =>
+        env.get(name).map(sym => Variable(sym))
+      case _ => None
+    })
   }
 
   /** Names a list of raw variables */

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/TailCallMarking.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/TailCallMarking.scala
@@ -1,0 +1,42 @@
+package org.mozartoz.bootcompiler
+package transform
+
+import ast._
+import oz._
+import symtab._
+
+object TailCallMarking extends Transformer {
+  def markTailCalls(name: Symbol, statement: Statement): Statement = statement match {
+    case call @ CallStatement(callable @ Variable(sym), args) =>
+      treeCopy.TailMarkerStatement(statement, call)
+
+    case CompoundStatement(stats) =>
+      val last = markTailCalls(name, stats.last)
+      treeCopy.CompoundStatement(statement, stats.dropRight(1) :+ last)
+      
+    case IfStatement(condition, trueExpression, falseExpression) =>
+      treeCopy.IfStatement(statement, condition,
+          markTailCalls(name, trueExpression),
+          markTailCalls(name, falseExpression))
+          
+    case MatchStatement(value, clauses, elseStatement) =>
+      treeCopy.MatchStatement(statement, value,
+          clauses.map(c => markMatchStatementClause(name, c)),
+          markTailCalls(name, elseStatement))
+      
+    case LocalStatement(declarations, stat) =>
+      treeCopy.LocalStatement(statement, declarations, markTailCalls(name, stat))
+      
+    case _ => statement
+  }
+  
+  def markMatchStatementClause(name: Symbol, clause: MatchStatementClause) =
+    treeCopy.MatchStatementClause(clause, clause.pattern, clause.guard, markTailCalls(name, clause.body))
+  
+  override def transformExpr(expression: Expression) = expression match {
+    case ProcExpression(name @ Some(Variable(sym)), args, body, flags) =>
+      treeCopy.ProcExpression(expression, name, args, markTailCalls(sym, transformStat(body)), flags)
+    
+    case _ => super.transformExpr(expression)
+  }
+}

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/TreeCopier.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/TreeCopier.scala
@@ -21,6 +21,9 @@ class TreeCopier {
 
   def CallStatement(tree: Node, callable: Expression, args: Seq[Expression]) =
     new CallStatement(callable, args).copyAttrs(tree)
+    
+  def TailMarkerStatement(tree: Node, call: CallStatement) =
+    new TailMarkerStatement(call).copyAttrs(tree)
 
   def IfStatement(tree: Node, condition: Expression,
       trueStatement: Statement, falseStatement: Statement) =
@@ -86,11 +89,11 @@ class TreeCopier {
 
   // Complex expressions
 
-  def ProcExpression(tree: Node, name: String, args: Seq[VariableOrRaw],
+  def ProcExpression(tree: Node, name: Option[VariableOrRaw], args: Seq[VariableOrRaw],
       body: Statement, flags: Seq[String]) =
     new ProcExpression(name, args, body, flags).copyAttrs(tree)
 
-  def FunExpression(tree: Node, name: String, args: Seq[VariableOrRaw],
+  def FunExpression(tree: Node, name: Option[VariableOrRaw], args: Seq[VariableOrRaw],
       body: Expression, flags: Seq[String]) =
     new FunExpression(name, args, body, flags).copyAttrs(tree)
 


### PR DESCRIPTION
Proc names are resolved and used for tail call detection (through the new TailCallMarking transformer)
Tail calls are wrapped within TailCallMarkers.
